### PR TITLE
feat: adding job role detail page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,7 +1369,6 @@
         "node": ">= 8"
       }
     },
-<<<<<<< HEAD
     "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -1396,8 +1395,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-=======
->>>>>>> 544fcd7cbad5fcba18b9bb6b1975fa2a3f898e60
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1580,7 +1577,6 @@
         "node": ">= 0.8"
       }
     },
-<<<<<<< HEAD
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1592,8 +1588,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-=======
->>>>>>> 544fcd7cbad5fcba18b9bb6b1975fa2a3f898e60
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -5191,7 +5185,6 @@
         "which": "^2.0.1"
       }
     },
-<<<<<<< HEAD
     "css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -5209,8 +5202,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
-=======
->>>>>>> 544fcd7cbad5fcba18b9bb6b1975fa2a3f898e60
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5338,14 +5329,11 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
-<<<<<<< HEAD
     "entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
-=======
->>>>>>> 544fcd7cbad5fcba18b9bb6b1975fa2a3f898e60
     "es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import nunjucks from "nunjucks";
 import bodyParser from "body-parser";
 
 import { getOpenJobRoles } from "./controllers/JobRoleController";
+import { getJobRoleById } from "./services/JobRoleService";
 
 const app = express();
 
@@ -27,3 +28,4 @@ app.get('/index', async (req: express.Request, res: express.Response) => {
 })
 
 app.get('/job-roles', getOpenJobRoles);
+app.get('/job-roles/:id', getJobRoleById);

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,8 +2,7 @@ import express from "express";
 import nunjucks from "nunjucks";
 import bodyParser from "body-parser";
 
-import { getOpenJobRoles } from "./controllers/JobRoleController";
-import { getJobRoleById } from "./services/JobRoleService";
+import { getOpenJobRoles, getJobRole } from "./controllers/JobRoleController";
 
 const app = express();
 
@@ -28,4 +27,4 @@ app.get('/index', async (req: express.Request, res: express.Response) => {
 })
 
 app.get('/job-roles', getOpenJobRoles);
-app.get('/job-roles/:id', getJobRoleById);
+app.get('/job-roles/:id', getJobRole);

--- a/src/controllers/JobRoleController.ts
+++ b/src/controllers/JobRoleController.ts
@@ -12,8 +12,8 @@ export const getOpenJobRoles = async (req: express.Request, res: express.Respons
 
 export const getJobRole = async (req: express.Request, res: express.Response): Promise<void> => {
 
-    var id = req.params.id;
-    var idNumber = Number(id);
+    const id = req.params.id;
+    const idNumber = Number(id);
 
     if(isNaN(idNumber)) {
         res.locals.errormessage = "Invalid job role id";

--- a/src/controllers/JobRoleController.ts
+++ b/src/controllers/JobRoleController.ts
@@ -20,7 +20,7 @@ export const getJobRole = async (req: express.Request, res: express.Response): P
         res.render('job-role-detail.html');
     } else {
         try {
-            res.render('job-role-detail.html', { jobRole: await getJobRoleById(req.params.id) });
+            res.render('job-role-detail.html', { jobRole: await getJobRoleById(idNumber) });
         } catch (e) {
             res.locals.errormessage = e.message;
             res.render('job-role-detail.html');

--- a/src/controllers/JobRoleController.ts
+++ b/src/controllers/JobRoleController.ts
@@ -11,10 +11,19 @@ export const getOpenJobRoles = async (req: express.Request, res: express.Respons
 }
 
 export const getJobRole = async (req: express.Request, res: express.Response): Promise<void> => {
-    try {
-        res.render('job-role-detail.html', { jobRole: await getJobRoleById(req.params.id) });
-    } catch (e) {
-        res.locals.errormessage = e.message;
+
+    var id = req.params.id;
+    var idNumber = Number(id);
+
+    if(isNaN(idNumber)) {
+        res.locals.errormessage = "Invalid job role id";
         res.render('job-role-detail.html');
+    } else {
+        try {
+            res.render('job-role-detail.html', { jobRole: await getJobRoleById(req.params.id) });
+        } catch (e) {
+            res.locals.errormessage = e.message;
+            res.render('job-role-detail.html');
+        }
     }
 }

--- a/src/controllers/JobRoleController.ts
+++ b/src/controllers/JobRoleController.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { getAllOpenJobRoles } from "../services/JobRoleService"
+import { getAllOpenJobRoles, getJobRoleById } from "../services/JobRoleService"
 
 export const getOpenJobRoles = async (req: express.Request, res: express.Response): Promise<void> => {
     try {
@@ -7,5 +7,14 @@ export const getOpenJobRoles = async (req: express.Request, res: express.Respons
     } catch (e) {
         res.locals.errormessage = e.message;
         res.render('list-job-roles.html');
+    }
+}
+
+export const getJobRole = async (req: express.Request, res: express.Response): Promise<void> => {
+    try {
+        res.render('job-role-detail.html', { jobRole: await getJobRoleById(req.params.id) });
+    } catch (e) {
+        res.locals.errormessage = e.message;
+        res.render('job-role-detail.html');
     }
 }

--- a/src/models/JobRoleDetailResponse.ts
+++ b/src/models/JobRoleDetailResponse.ts
@@ -1,0 +1,12 @@
+export type JobRoleDetailResponse = {
+    roleId: number,
+    roleName: string,
+    location: string,
+    capability: string,
+    band: string,
+    closingDate: string,
+    roleStatus: number,
+    description: string,
+    responsibilities: string,
+    jobLink: string
+}

--- a/src/services/JobRoleService.ts
+++ b/src/services/JobRoleService.ts
@@ -20,12 +20,12 @@ export const getAllOpenJobRoles = async (): Promise<JobRoleResponse[]> => {
     }
 }
 
-export const getJobRoleById = async (id: string): Promise <JobRoleDetailResponse> => {
+export const getJobRoleById = async (id: Number): Promise <JobRoleDetailResponse> => {
     try {
         const response: AxiosResponse = await axios.get(URL + "/" + id);
         return response.data;
 
     } catch (e) {
-        throw new Error("Could not get job role");
+        throw new Error('We encountered a problem while trying to retrieve this job role. Please try again later!');
     }
 }

--- a/src/services/JobRoleService.ts
+++ b/src/services/JobRoleService.ts
@@ -20,7 +20,7 @@ export const getAllOpenJobRoles = async (): Promise<JobRoleResponse[]> => {
     }
 }
 
-export const getJobRoleById = async (id: Number): Promise <JobRoleDetailResponse> => {
+export const getJobRoleById = async (id: number): Promise <JobRoleDetailResponse> => {
     try {
         const response: AxiosResponse = await axios.get(URL + "/" + id);
         return response.data;

--- a/src/services/JobRoleService.ts
+++ b/src/services/JobRoleService.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { JobRoleResponse } from "../models/JobRoleResponse";
+import { JobRoleDetailResponse } from "../models/JobRoleDetailResponse";
 
 axios.defaults.baseURL = process.env.API_URL || "http://localhost:8080/";
 
@@ -16,5 +17,15 @@ export const getAllOpenJobRoles = async (): Promise<JobRoleResponse[]> => {
         } else {
             throw new Error(e.message);
         }
+    }
+}
+
+export const getJobRoleById = async function (id: string): Promise <JobRoleDetailResponse> {
+    try {
+        const response: AxiosResponse = await axios.get(URL + "/" + id);
+        return response.data;
+
+    } catch (e) {
+        throw new Error("Could not get job role");
     }
 }

--- a/src/services/JobRoleService.ts
+++ b/src/services/JobRoleService.ts
@@ -20,7 +20,7 @@ export const getAllOpenJobRoles = async (): Promise<JobRoleResponse[]> => {
     }
 }
 
-export const getJobRoleById = async function (id: string): Promise <JobRoleDetailResponse> {
+export const getJobRoleById = async (id: string): Promise <JobRoleDetailResponse> => {
     try {
         const response: AxiosResponse = await axios.get(URL + "/" + id);
         return response.data;

--- a/test/integration/JobRoleIntegrationTest.ts
+++ b/test/integration/JobRoleIntegrationTest.ts
@@ -16,4 +16,18 @@ describe.skip('JobRoleIntegration', function () {
             return;
         }
     });
+
+    it('getJobRoleById should return job role details', async () => {
+        try {
+            const response: AxiosResponse = await axios.get(URL);  
+            
+            const data = response.data;
+            const status = response.status;
+
+            expect(status).to.equal(200);
+            expect(data).to.not.be.null;
+        } catch (e) {
+            return;
+        }
+    })
 })

--- a/test/integration/JobRoleIntegrationTest.ts
+++ b/test/integration/JobRoleIntegrationTest.ts
@@ -18,16 +18,12 @@ describe.skip('JobRoleIntegration', function () {
     });
 
     it('getJobRoleById should return job role details', async () => {
-        try {
-            const response: AxiosResponse = await axios.get(URL);  
+            const response: AxiosResponse = await axios.get(URL + "/");  
             
             const data = response.data;
             const status = response.status;
 
             expect(status).to.equal(200);
             expect(data).to.not.be.null;
-        } catch (e) {
-            return e.message;
-        }
     })
 })

--- a/test/integration/JobRoleIntegrationTest.ts
+++ b/test/integration/JobRoleIntegrationTest.ts
@@ -27,7 +27,7 @@ describe.skip('JobRoleIntegration', function () {
             expect(status).to.equal(200);
             expect(data).to.not.be.null;
         } catch (e) {
-            return;
+            return e.message;
         }
     })
 })

--- a/test/ui/ApplicantTest.ts
+++ b/test/ui/ApplicantTest.ts
@@ -37,8 +37,36 @@ describe('Applicant UI Test', async () => {
         const endPoint2: string = 'job-roles/1';
         await driver.get(baseUrl + endPoint2);
         
-       const name = await driver.findElement(By.id('roleName')).getText();
+        const name = await driver.findElement(By.id('roleName')).getText();
         expect(name).to.equal('Software Engineer');
+
+        await driver.quit();
+
+    });
+
+    it.only('As an applicant, I can click on a job link and be taken to the correct page', async () => {
+        const driver = new Builder().
+        withCapabilities(Capabilities.chrome()).
+        build();
+
+        const originalWindowHandle = await driver.getWindowHandle();
+
+        const endPoint: string = 'job-roles/1';
+        await driver.get(baseUrl + endPoint);
+
+        const expectedUrl = "https://login.microsoftonline.com/";
+
+
+        await driver.findElement(By.linkText("Job Specification")).click();
+
+        const newWindowHandles = await driver.getAllWindowHandles();
+        const newWindowHandle = newWindowHandles.find(handle => handle !== originalWindowHandle);
+        await driver.switchTo().window(newWindowHandle as string);
+
+
+        const actualUrl = await driver.getCurrentUrl();
+        console.log("actual URL: " + actualUrl);
+        expect(actualUrl).to.include(expectedUrl);
 
         await driver.quit();
 

--- a/test/ui/ApplicantTest.ts
+++ b/test/ui/ApplicantTest.ts
@@ -37,7 +37,7 @@ describe('Applicant UI Test', async () => {
         const endPoint2: string = 'job-roles/1';
         await driver.get(baseUrl + endPoint2);
         
-       const name = await driver.findElement(By.id('superUniqueName')).getText();
+       const name = await driver.findElement(By.id('roleName')).getText();
         expect(name).to.equal('Software Engineer');
 
         await driver.quit();

--- a/test/ui/ApplicantTest.ts
+++ b/test/ui/ApplicantTest.ts
@@ -20,4 +20,25 @@ describe('Applicant UI Test', async () => {
 
         await driver.quit();
     });
+
+    it('As an applicant, I am able to click on a job role and see the details', async () => {
+        const driver = new Builder().
+        withCapabilities(Capabilities.chrome()).
+        build();
+
+        const endPoint: string = 'job-roles';
+        await driver.get(baseUrl + endPoint);
+        //idk what I'm doing this is from chat
+        const element = driver.findElement(By.id('roleNameInList'));
+        driver.executeScript("arguments[0].scrollIntoView(true);", element);
+
+        await driver.findElement(By.linkText("Software Engineer")).click();
+
+        const name = await driver.findElement(By.id('roleName'));
+
+        expect(name).to.equal('Software Engineer');
+
+        await driver.quit();
+
+    });
 });

--- a/test/ui/ApplicantTest.ts
+++ b/test/ui/ApplicantTest.ts
@@ -28,14 +28,16 @@ describe('Applicant UI Test', async () => {
 
         const endPoint: string = 'job-roles';
         await driver.get(baseUrl + endPoint);
-        //idk what I'm doing this is from chat
+        
         const element = driver.findElement(By.id('roleNameInList'));
         driver.executeScript("arguments[0].scrollIntoView(true);", element);
 
         await driver.findElement(By.linkText("Software Engineer")).click();
 
-        const name = await driver.findElement(By.id('roleName'));
-
+        const endPoint2: string = 'job-roles/1';
+        await driver.get(baseUrl + endPoint2);
+        
+       const name = await driver.findElement(By.id('superUniqueName')).getText();
         expect(name).to.equal('Software Engineer');
 
         await driver.quit();

--- a/test/ui/ApplicantTest.ts
+++ b/test/ui/ApplicantTest.ts
@@ -44,7 +44,7 @@ describe('Applicant UI Test', async () => {
 
     });
 
-    it.only('As an applicant, I can click on a job link and be taken to the correct page', async () => {
+    it('As an applicant, I can click on a job link and be taken to the correct page', async () => {
         const driver = new Builder().
         withCapabilities(Capabilities.chrome()).
         build();

--- a/test/unit/controller/JobRoleControllerTest.ts
+++ b/test/unit/controller/JobRoleControllerTest.ts
@@ -5,6 +5,7 @@ import * as JobRoleController from "../../../src/controllers/JobRoleController";
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { Request } from "express";
+import { JobRoleDetailResponse } from "../../../src/models/JobRoleDetailResponse";
 
 const jobRoleResponse: JobRoleResponse = {
     roleId: 1,
@@ -15,6 +16,20 @@ const jobRoleResponse: JobRoleResponse = {
     closingDate: "2024-08-15 23:59:59",
     roleStatus: 1
 }
+
+const jobRoleDetailResponse: JobRoleDetailResponse = {
+    roleId: 2,
+    roleName: "Product Owner",
+    location: "Toronto, CA",
+    capability: "Digital Services",
+    band: "Trainee",
+    closingDate: "2024-08-15 23:59:59",
+    roleStatus: 1,
+    description: "Oversees products.",
+    responsibilities: "planning, organizing",
+    jobLink: "https://kainoscareerportal.com/ProductOwner"
+}
+
 
 describe('JobRoleController', function () {
     afterEach(() => {
@@ -64,5 +79,34 @@ describe('JobRoleController', function () {
             expect(res.render.calledWith('list-job-roles.html')).to.be.true;
             expect(res.locals.errorMessage).to.equal(errorMessage);
         });
+    })
+
+    describe('getJobRoleById', function () {
+        it('should render view with correct job role when service returns a job role', async() => {
+            sinon.stub(JobRoleService, 'getJobRoleById').resolves(jobRoleDetailResponse);
+
+            const req = { params: "2" };
+            const res = { render: sinon.spy() };
+
+            await JobRoleController.getJobRole(req as any, res as any);
+
+            expect(res.render.calledOnce).to.be.true;
+            expect(res.render.calledWith('job-role-detail.html', { jobRole: jobRoleDetailResponse})).to.be.true;
+        });
+
+        it('should return an error when service returns error', async() => {
+            const errorMessage: string = 'Error message';
+            sinon.stub(JobRoleService, 'getJobRoleById').rejects(new Error(errorMessage));
+
+            const req = { params: "2" };
+            const res = { render: sinon.spy(), locals: { errormessage: ''} };
+
+            await JobRoleController.getJobRole(req as any, res as any);
+
+            expect(res.render.calledOnce).to.be.true;
+            expect(res.render.calledWith('job-role-detail.html')).to.be.true;
+            expect(res.locals.errormessage).to.equal(errorMessage);
+        });
+
     })
 })

--- a/test/unit/controller/JobRoleControllerTest.ts
+++ b/test/unit/controller/JobRoleControllerTest.ts
@@ -82,10 +82,11 @@ describe('JobRoleController', function () {
     })
 
     describe('getJobRoleById', function () {
+        
         it('should render view with correct job role when service returns a job role', async() => {
             sinon.stub(JobRoleService, 'getJobRoleById').resolves(jobRoleDetailResponse);
 
-            const req = { params: "2" };
+            const req = { params: { id: 2 } };
             const res = { render: sinon.spy() };
 
             await JobRoleController.getJobRole(req as any, res as any);
@@ -93,12 +94,26 @@ describe('JobRoleController', function () {
             expect(res.render.calledOnce).to.be.true;
             expect(res.render.calledWith('job-role-detail.html', { jobRole: jobRoleDetailResponse})).to.be.true;
         });
+        
 
-        it('should return an error when service returns error', async() => {
+        it('should return an error message when service returns error', async() => {
             const errorMessage: string = 'Error message';
             sinon.stub(JobRoleService, 'getJobRoleById').rejects(new Error(errorMessage));
 
-            const req = { params: "2" };
+            const req = { params: { id: 2 } };
+            const res = { render: sinon.spy(), locals: { errormessage: ''} };
+
+            await JobRoleController.getJobRole(req as any, res as any);
+
+            expect(res.render.calledOnce).to.be.true;
+            expect(res.render.calledWith('job-role-detail.html')).to.be.true;
+            expect(res.locals.errormessage).to.equal(errorMessage);
+        }); 
+
+        it('should return an error message when an invalid id is entered', async() => {
+            const errorMessage: string = 'Invalid job role id';
+
+            const req = { params: "gcuieobcue" };
             const res = { render: sinon.spy(), locals: { errormessage: ''} };
 
             await JobRoleController.getJobRole(req as any, res as any);

--- a/test/unit/services/JobRoleServiceTest.ts
+++ b/test/unit/services/JobRoleServiceTest.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { JobRoleResponse } from "../../../src/models/JobRoleResponse";
-import { getAllOpenJobRoles, URL } from '../../../src/services/JobRoleService';
+import { getAllOpenJobRoles, URL, getJobRoleById } from '../../../src/services/JobRoleService';
 import { expect } from 'chai';
+import { JobRoleDetailResponse } from "../../../src/models/JobRoleDetailResponse";
 
 const jobRoleResponse: JobRoleResponse = {
     roleId: 1,
@@ -12,6 +13,19 @@ const jobRoleResponse: JobRoleResponse = {
     band: "Trainee",
     closingDate: "2024-08-15 23:59:59",
     roleStatus: 1
+}
+
+const jobRoleDetailResponse: JobRoleDetailResponse = {
+    roleId: 2,
+    roleName: "Product Owner",
+    location: "Toronto, CA",
+    capability: "Digital Services",
+    band: "Trainee",
+    closingDate: "2024-08-15 23:59:59",
+    roleStatus: 1,
+    description: "Oversees products.",
+    responsibilities: "planning, organizing",
+    jobLink: "https://kainoscareerportal.com/ProductOwner"
 }
 
 const mock = new MockAdapter(axios);
@@ -45,6 +59,28 @@ describe('JobRoleService', function () {
                 await getAllOpenJobRoles();
             } catch (e) {
                 expect(e.message).to.equal('Could not get job roles');
+                return;
+            }
+        })
+    })
+
+    describe('getJobRoleById', function () {
+        it('should return job with correct id', async () => {
+
+            mock.onGet(URL + "/2").reply(200, jobRoleDetailResponse);
+
+            const result = await getJobRoleById("2");
+
+            expect(result).to.deep.equal(jobRoleDetailResponse);
+        })
+
+        it('should return exception when 500 error returned from axios', async () => {
+            mock.onGet(URL + "/2").reply(500);
+
+            try {
+                await getJobRoleById("2");
+            } catch (e) {
+                expect(e.message).to.equal('Could not get job role');
                 return;
             }
         })

--- a/test/unit/services/JobRoleServiceTest.ts
+++ b/test/unit/services/JobRoleServiceTest.ts
@@ -69,7 +69,7 @@ describe('JobRoleService', function () {
 
             mock.onGet(URL + "/2").reply(200, jobRoleDetailResponse);
 
-            const result = await getJobRoleById("2");
+            const result = await getJobRoleById(2);
 
             expect(result).to.deep.equal(jobRoleDetailResponse);
         })
@@ -78,9 +78,9 @@ describe('JobRoleService', function () {
             mock.onGet(URL + "/2").reply(500);
 
             try {
-                await getJobRoleById("2");
+                await getJobRoleById(2);
             } catch (e) {
-                expect(e.message).to.equal('Could not get job role');
+                expect(e.message).to.equal('We encountered a problem while trying to retrieve this job role. Please try again later!');
                 return;
             }
         })

--- a/test/unit/views/indexTest.ts
+++ b/test/unit/views/indexTest.ts
@@ -31,7 +31,7 @@ describe('index.html', () => {
         const $ = cheerio.load(renderedHtml);
 
         const expectedStyleSheets = [
-            'style.css'
+            '/style.css'
         ];
 
         const styleLinkTags = $('[rel="stylesheet"]');

--- a/test/unit/views/jobRoleDetailTest.ts
+++ b/test/unit/views/jobRoleDetailTest.ts
@@ -56,8 +56,6 @@ describe('job-role-detail.html', () => {
         
         const renderedHtml = nunjucks.render(templateFile, context);
 
-        const $ = cheerio.load(renderedHtml);
-
         const expectedHtml = 
         `<td>
             

--- a/test/unit/views/jobRoleDetailTest.ts
+++ b/test/unit/views/jobRoleDetailTest.ts
@@ -1,0 +1,20 @@
+import path from "path";
+import {expect} from 'chai';
+import nunjucks from "nunjucks";
+import * as cheerio from 'cheerio';
+
+describe('job-role-detail.html', () => {
+    const templateFile = 'job-role-detail.html';
+
+    const viewsPath = path.resolve(__dirname, '../../../views');
+    nunjucks.configure(viewsPath, { autoescape: true });
+
+    it('should display error message when error is provided', () => {
+        const context = { errormessage: "Error message" };
+
+        const renderedHtml = nunjucks.render(templateFile, context);
+
+        expect(renderedHtml).to.include('<h2 style="color:red;font-weight:bold;">Error message</h2>');
+    });
+
+});

--- a/test/unit/views/jobRoleDetailTest.ts
+++ b/test/unit/views/jobRoleDetailTest.ts
@@ -1,7 +1,6 @@
 import path from "path";
 import {expect} from 'chai';
 import nunjucks from "nunjucks";
-import * as cheerio from 'cheerio';
 
 describe('job-role-detail.html', () => {
     const templateFile = 'job-role-detail.html';

--- a/test/unit/views/jobRoleDetailTest.ts
+++ b/test/unit/views/jobRoleDetailTest.ts
@@ -17,50 +17,61 @@ describe('job-role-detail.html', () => {
         expect(renderedHtml).to.include('<h2 style="color:red;font-weight:bold;">Error message</h2>');
     });
 
-    it('should display a job role when the job role exists in the db', () => {
+    it('should display individual job role information when the job role exists in the db', () => {
         const context = {
-            role: [
+            jobRole: 
                 { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 1, description: "full stack", responsibilities: "coding", jobLink: "www.softwareengineer.com" }
-            ]
         };
 
         const renderedHtml = nunjucks.render(templateFile, context);
         const $ = cheerio.load(renderedHtml);
 
+        const listItems = $('tr > td');
 
-        const headerRow = $('tr').eq(0);
-        const dataRows = $('tr').not(headerRow);
+        const items = listItems.map((index, el) => {
+        return $(el).text().trim();
+        }).get();
 
-        const actualNumDataRows = dataRows.length;
-        const expectedNumDataRows = context.role.length;
+        const expectedData = [
+            'Software Engineer',
+            'Toronto',
+            'Development',
+            'B2',
+            '2024-08-01',
+            'Open',
+            'full stack',
+            'coding',
+            'Job Specification'
+          ];
 
-        expect(actualNumDataRows).to.equal(expectedNumDataRows);
+        expect(items).to.deep.equal(expectedData);
 
     });
 
-    it('should display open status for a job role with role status of 1', () => {
+    it('should display open status for an individual job role with role status of 1', () => {
         const context = {
-            roles: [
+            jobRole: 
                 { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 1, description: 'full stack', responsibilities: 'coding', jobLink: 'www.softwareengineer.com' },
-            ]
-        };
-
+        }; 
+        
         const renderedHtml = nunjucks.render(templateFile, context);
+
+        const $ = cheerio.load(renderedHtml);
+
         const expectedHtml = 
         `<td>
             
             Open
             
-        </td>`
+        </td>`;
 
         expect(renderedHtml).to.include(expectedHtml);
     });
 
-    it('should display closed status for a job role with role status of 0', () => {
+    it('should display closed status for an individual job role with role status of 0', () => {
         const context = {
-            roles: [
-                { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 0 },
-            ]
+            jobRole:
+                { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 0, description: 'full stack', responsibilities: 'coding', jobLink: 'www.softwareengineer.com' },
         };
 
         const renderedHtml = nunjucks.render(templateFile, context);

--- a/test/unit/views/jobRoleDetailTest.ts
+++ b/test/unit/views/jobRoleDetailTest.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import {expect} from 'chai';
 import nunjucks from "nunjucks";
+import * as cheerio from 'cheerio';
 
 describe('job-role-detail.html', () => {
     const templateFile = 'job-role-detail.html';
@@ -14,6 +15,63 @@ describe('job-role-detail.html', () => {
         const renderedHtml = nunjucks.render(templateFile, context);
 
         expect(renderedHtml).to.include('<h2 style="color:red;font-weight:bold;">Error message</h2>');
+    });
+
+    it('should display a job role when the job role exists in the db', () => {
+        const context = {
+            role: [
+                { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 1, description: "full stack", responsibilities: "coding", jobLink: "www.softwareengineer.com" }
+            ]
+        };
+
+        const renderedHtml = nunjucks.render(templateFile, context);
+        const $ = cheerio.load(renderedHtml);
+
+
+        const headerRow = $('tr').eq(0);
+        const dataRows = $('tr').not(headerRow);
+
+        const actualNumDataRows = dataRows.length;
+        const expectedNumDataRows = context.role.length;
+
+        expect(actualNumDataRows).to.equal(expectedNumDataRows);
+
+    });
+
+    it('should display open status for a job role with role status of 1', () => {
+        const context = {
+            roles: [
+                { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 1, description: 'full stack', responsibilities: 'coding', jobLink: 'www.softwareengineer.com' },
+            ]
+        };
+
+        const renderedHtml = nunjucks.render(templateFile, context);
+        const expectedHtml = 
+        `<td>
+            
+            Open
+            
+        </td>`
+
+        expect(renderedHtml).to.include(expectedHtml);
+    });
+
+    it('should display closed status for a job role with role status of 0', () => {
+        const context = {
+            roles: [
+                { roleName: 'Software Engineer', location: 'Toronto', capability: 'Development', band: 'B2', closingDate: '2024-08-01', roleStatus: 0 },
+            ]
+        };
+
+        const renderedHtml = nunjucks.render(templateFile, context);
+        const expectedHtml = 
+        `<td>
+            
+            Closed
+            
+        </td>`
+       
+        expect(renderedHtml).to.include(expectedHtml);
     });
 
 });

--- a/views/job-role-detail.html
+++ b/views/job-role-detail.html
@@ -21,7 +21,7 @@
 
     </tr>
     <tr>
-        <td>{{ jobRole.roleName }}</td>
+        <td id="roleName">{{ jobRole.roleName }}</td>
         <td>{{ jobRole.location }}</td>
         <td>{{ jobRole.capability }}</td>
         <td>{{ jobRole.band }}</td>

--- a/views/job-role-detail.html
+++ b/views/job-role-detail.html
@@ -21,7 +21,7 @@
 
     </tr>
     <tr>
-        <td id="superUniqueName">{{ jobRole.roleName }}</td>
+        <td id="roleName">{{ jobRole.roleName }}</td>
         <td>{{ jobRole.location }}</td>
         <td>{{ jobRole.capability }}</td>
         <td>{{ jobRole.band }}</td>

--- a/views/job-role-detail.html
+++ b/views/job-role-detail.html
@@ -1,0 +1,41 @@
+{% extends "pageTemplate.njk" %}
+
+{% block content %}
+<h1>Job Role Details</h1>
+
+{% if errormessage %}
+<h2 style="color:red;font-weight:bold;">{{ errormessage }}</h2>
+{% endif %}
+
+{% if jobRole %}
+<table>
+    <tr>
+        <th>Role Name</th>
+        <th>Location</th>
+        <th>Capability</th>
+        <th>Band</th>
+        <th>Closing Date</th>
+        <th>Role Status</th>
+        <th>Description</th>
+        <th>Responsibilities</th>
+        <th>Job Link</th>
+
+    </tr>
+    <tr>
+        <td>{{ jobRole.roleName }}</td>
+        <td>{{ jobRole.location }}</td>
+        <td>{{ jobRole.capability }}</td>
+        <td>{{ jobRole.band }}</td>
+        <td>{{ jobRole.closingDate }}</td>
+        <td>
+            {% if jobRole.roleStatus == 1 %}
+            Open
+            {% else %}
+            Closed
+            {% endif %}
+        </td>
+        <td>{{ jobRole.description }}</td>
+        <td>{{ jobRole.responsibilities }}</td>
+        <td>{{ jobRole.jobLink }}</td>
+    </tr>
+</table>

--- a/views/job-role-detail.html
+++ b/views/job-role-detail.html
@@ -7,7 +7,6 @@
 <h2 style="color:red;font-weight:bold;">{{ errormessage }}</h2>
 {% endif %}
 
-{% if jobRole %}
 <table>
     <tr>
         <th>Role Name</th>
@@ -36,6 +35,9 @@
         </td>
         <td>{{ jobRole.description }}</td>
         <td>{{ jobRole.responsibilities }}</td>
-        <td>{{ jobRole.jobLink }}</td>
+        <td> 
+            <a href="{{ jobRole.jobLink }}" target="_blank">Job Specification</a>
+        </td>
     </tr>
 </table>
+{% endblock %}

--- a/views/job-role-detail.html
+++ b/views/job-role-detail.html
@@ -5,8 +5,8 @@
 
 {% if errormessage %}
 <h2 style="color:red;font-weight:bold;">{{ errormessage }}</h2>
-{% endif %}
 
+{% else %}
 <table>
     <tr>
         <th>Role Name</th>
@@ -40,4 +40,5 @@
         </td>
     </tr>
 </table>
+{% endif %}
 {% endblock %}

--- a/views/job-role-detail.html
+++ b/views/job-role-detail.html
@@ -21,7 +21,7 @@
 
     </tr>
     <tr>
-        <td id="roleName">{{ jobRole.roleName }}</td>
+        <td id="superUniqueName">{{ jobRole.roleName }}</td>
         <td>{{ jobRole.location }}</td>
         <td>{{ jobRole.capability }}</td>
         <td>{{ jobRole.band }}</td>

--- a/views/list-job-roles.html
+++ b/views/list-job-roles.html
@@ -19,7 +19,9 @@
     </tr>
     {% for role in roles %}
     <tr>
-        <td>{{ role.roleName }}</td>
+        <td>
+            <a href="/job-roles/{{role.roleId}}" target="_blank">{{ role.roleName }}</a>
+        </td>
         <td>{{ role.location }}</td>
         <td>{{ role.capability }}</td>
         <td>{{ role.band }}</td>

--- a/views/list-job-roles.html
+++ b/views/list-job-roles.html
@@ -20,7 +20,7 @@
     {% for role in roles %}
     <tr>
         <td>
-            <a href="/job-roles/{{role.roleId}}" target="_blank">{{ role.roleName }}</a>
+            <a href="/job-roles/{{role.roleId}}" target="_blank" id="roleNameInList">{{ role.roleName }}</a>
         </td>
         <td>{{ role.location }}</td>
         <td>{{ role.capability }}</td>

--- a/views/pageTemplate.njk
+++ b/views/pageTemplate.njk
@@ -3,8 +3,8 @@
     <head>
         <meta charset="UTF-8">
         <title> Kainos Career Portal</title>
-        <link rel="stylesheet" href="style.css"/>
-        <link rel="icon" href="images/Green_Circle_Favicon.png" type="image/png">
+        <link rel="stylesheet" href="/style.css"/>
+        <link rel="icon" href="/images/Green_Circle_Favicon.png" type="image/png">
     </head>
 
     <body>
@@ -14,7 +14,7 @@
                 <div class="header__container">
                     <div class="header__logo-wrap">
                         <a>
-                            <img class="header__logo-img" src="images/Kainos_Logo_Blue_Transparent.png" alt="Kainos_Logo"/>
+                            <img class="header__logo-img" src="/images/Kainos_Logo_Blue_Transparent.png" alt="Kainos_Logo"/>
                         </a>
                     </div>
                 </div>
@@ -27,7 +27,7 @@
             <div class="footer__container">
                 <div class="footer__logo">
                     <picture>
-                        <img alt="logo" class="footer__logo-image" src="images/Kainos-Logo_White_Transparent.png?mode=crop&width=100"/>
+                        <img alt="logo" class="footer__logo-image" src="/images/Kainos-Logo_White_Transparent.png?mode=crop&width=100"/>
                     </picture>
                 </div>
             </div>
@@ -36,7 +36,7 @@
                 </div>
             </div>
                 <div class="footer__bottom">
-                    <div class="footer__bg-image" style="background-image: url('images/Flux_White_Footer.png');"></div>
+                    <div class="footer__bg-image" style="background-image: url('/images/Flux_White_Footer.png');"></div>
                     <div class="footer__container footer__container--image container">
                         <div class="footer__copyrights">Copyright &#169;2024 Kainos. Registered in NI NI019370</div>
                     </div>

--- a/views/style.css
+++ b/views/style.css
@@ -99,3 +99,14 @@ body {
     margin-top: 10px;
     font-size: 1.0rem;
 }
+
+th, td {
+    padding-top: 10px;
+    padding-bottom: 20px;
+    padding-left: 30px;
+    padding-right: 40px;
+  }
+
+td {
+    vertical-align: top;
+}


### PR DESCRIPTION
### Describe your changes
Added the frontend logic for a job role details page. From the job role list page, users can now click on a job role name to view more details about the job. In the job role detail page there are now 3 additional columns: description, responsibilities, and job link. The job link will take the user to the Kainos job specification on Sharepoint.

UI changes to the job roles list page (I made the role names links so users can click to view the information of a specific job role):

![Screenshot 2024-08-07 at 12 29 46 PM](https://github.com/user-attachments/assets/b0c62716-4031-4846-b7d1-c6cff19954ba)

## Issue ticket number and link
US002
https://tasks.office.com/kainos.com/en-US/Home/Planner/#/plantaskboard?groupId=3a4655dc-9106-4ae5-b900-b6ebe83dfab5&planId=Ww6vdHsxYkuv4tMevZj1_ZYAFksm

#### Checklist before requesting a review
#### General
- [x] I have performed a self-review of my code.
- [x] Code changes are considered complete for the given story (i.e., the comments from code review are addressed).
- [x] The commit title follows conventional commit standards.
- [x] I have put the PR link into the planner.
- [x] The PR has a clear and descriptive title and a detailed description of the changes.
- [x] Code builds cleanly without any errors or warnings.
 
#### Code Quality
- [x] I have run linting and there were no errors.
 
#### Testing
- [x] New functionality is tested.
- [x] All unit and integration tests passed.
- [x] I have run accessibility tests and there were no errors.
 
#### Deployment
- [x] Documentation has been updated where needed.
 
#### Security
- [x] No sensitive data is hard-coded or exposed.
